### PR TITLE
Simplify plugin context handling

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -45,14 +45,17 @@ Let's implement the simple plugin to route numbers as either even or odd ones.
 
       static match(reminder) {
         return (number) => {
-          if (!Number.isInteger(number) || number === 0) { return false; }
-          return number % 2 === reminder;
+          if (!Number.isInteger(number) || number === 0) { return null; }
+          if (number % 2 !== reminder) { return null; }
+          return { reminder };
         };
       }
     }
     ```
 
-    **`match`** expects routing context and returns matching callback. Mathing callback is used during dispatch process. Router invokes matching context with the routing subject.
+    **`match`** expects routing context and returns matching function. Matching function is invoked during dispatch process.
+    When all conditions are met (successfull "match"), matching function returns context object. So, it could empty object or class instance.
+    When any of conditions are not met, matching function returns null.
 
 The plugin would be accessible on router's instance by lower-cased class name as
 

--- a/lib/BasePlugin.js
+++ b/lib/BasePlugin.js
@@ -1,14 +1,16 @@
+const Route = require('./Route');
+
 class BasePlugin {
   constructor(routes) {
     this.routes = routes;
   }
 
   appendRoute(...args) {
-    this.routes.push({
-      callback: args.pop(),
-      match: this.constructor.match(...args),
-      pluginName: this.constructor.pluginName,
-    });
+    this.routes.push(new Route(
+      args.pop(), // callback
+      this.constructor.match(...args), // matcher
+      this.constructor.pluginName, // plugin name
+    ));
     return this;
   }
 
@@ -18,10 +20,6 @@ class BasePlugin {
 
   static match() {
     throw new Error('Not implemented');
-  }
-
-  static ctx() {
-    return {};
   }
 }
 

--- a/lib/Route.js
+++ b/lib/Route.js
@@ -1,0 +1,19 @@
+class Route {
+  constructor(callback, matcher, pluginName) {
+    this.callback = callback;
+    this.matcher = matcher;
+    this.pluginName = pluginName;
+    this.ctx = undefined;
+  }
+
+  match(...args) {
+    this.ctx = this.matcher(...args);
+    return !!this.ctx;
+  }
+
+  respond(...args) {
+    return this.callback.apply(null, [this.ctx || {}, ...args]);
+  }
+}
+
+module.exports = Route;

--- a/lib/ServerlessRouter.js
+++ b/lib/ServerlessRouter.js
@@ -33,8 +33,7 @@ class ServerlessRouter {
     const matchingRoute = this.routes.find(r => r.match(...args));
 
     if (matchingRoute) {
-      const ctx = this[matchingRoute.pluginName].constructor.ctx(...args);
-      return matchingRoute.callback.apply(null, [ctx, ...args]);
+      return matchingRoute.respond(...args);
     }
 
     if (this.mismatchHandler) {

--- a/lib/__tests__/BasePlugin.js
+++ b/lib/__tests__/BasePlugin.js
@@ -19,8 +19,9 @@ describe('BasePlugin', () => {
       plugin.appendRoute('a', 'b', 'c', 'd', 'e', 'f');
       expect(plugin.routes).toEqual([{
         callback: 'f',
-        match: 42,
+        matcher: 42,
         pluginName: 'baseplugin',
+        ctx: undefined,
       }]);
       expect(BasePlugin.match).toHaveBeenCalledTimes(1);
       expect(BasePlugin.match).toHaveBeenCalledWith('a', 'b', 'c', 'd', 'e');

--- a/lib/__tests__/Route.js
+++ b/lib/__tests__/Route.js
@@ -1,0 +1,36 @@
+const Route = require('../Route');
+
+describe('Route', () => {
+  describe('countructor', () =>
+    test('initializes it\'s attributes', () => {
+      const route = new Route('callback', 'matcher', 'pluginName');
+      expect(route.callback).toEqual('callback');
+      expect(route.matcher).toEqual('matcher');
+      expect(route.pluginName).toEqual('pluginName');
+      expect(route.ctx).toEqual(undefined);
+    }));
+
+  describe('.match', () => {
+    describe('on match', () =>
+      test('sets context and responds with matching result', () => {
+        const matcher = jest.fn(() => ({ foo: 'bar' }));
+        const route = new Route('callback', matcher, 'pluginName');
+        const matchingResult = route.match('baz', 'qux');
+        expect(matchingResult).toBe(true);
+        expect(route.ctx).toEqual({ foo: 'bar' });
+        expect(matcher).toHaveBeenCalledTimes(1);
+        expect(matcher).toHaveBeenCalledWith('baz', 'qux');
+      }));
+
+    describe('on mismatch', () =>
+      test('sets context and responds with matching result', () => {
+        const matcher = jest.fn(() => undefined);
+        const route = new Route('callback', matcher, 'pluginName');
+        const matchingResult = route.match('baz', 'qux');
+        expect(matchingResult).toBe(false);
+        expect(route.ctx).toEqual(undefined);
+        expect(matcher).toHaveBeenCalledTimes(1);
+        expect(matcher).toHaveBeenCalledWith('baz', 'qux');
+      }));
+  });
+});

--- a/lib/__tests__/__fixtures__/EvenOddPlugin.js
+++ b/lib/__tests__/__fixtures__/EvenOddPlugin.js
@@ -12,13 +12,10 @@ class EvenOddPlugin extends BasePlugin {
 
   static match(reminder) {
     return (number) => {
-      if (!Number.isInteger(number) || number === 0) { return false; }
-      return number % 2 === reminder;
+      if (!Number.isInteger(number) || number === 0) { return null; }
+      if (number % 2 !== reminder) { return null; }
+      return { reminder };
     };
-  }
-
-  static ctx(reminder) {
-    return { reminder };
   }
 
   static get pluginName() { return 'evenodd'; }

--- a/lib/__tests__/__fixtures__/TypePlugin.js
+++ b/lib/__tests__/__fixtures__/TypePlugin.js
@@ -38,7 +38,7 @@ class TypePlugin extends BasePlugin {
     let matcher = () => null;
     const subjectType = getType(subject);
     if (subjectType === '[object String]') {
-      matcher = target => getType(target) === subject;
+      matcher = target => (getType(target) === subject ? {} : null);
     }
     if (subjectType === '[object Function]') {
       matcher = subject;

--- a/lib/__tests__/__fixtures__/WeekdayPlugin.js
+++ b/lib/__tests__/__fixtures__/WeekdayPlugin.js
@@ -31,7 +31,7 @@ class WeekdayPlugin extends BasePlugin {
   }
 
   static match(dayIndex) {
-    return date => date.getDay() === dayIndex;
+    return date => (date.getDay() === dayIndex ? {} : null);
   }
 
   static get pluginName() { return 'weekday'; }


### PR DESCRIPTION
#### Short description of what this resolves:
Simplify plugin context handling

#### Changes proposed in this pull request:
* Implement `Route` class, so we can encapsulate methods to match, invoke response and grab routing context in case of success.
